### PR TITLE
Real gray code

### DIFF
--- a/Software/North Star Gen 2/North Star Calibrator/captureGraycodes.py
+++ b/Software/North Star Gen 2/North Star Calibrator/captureGraycodes.py
@@ -8,6 +8,7 @@ import intelutils
 
 rigel = False
 realsense = True
+mock = False
 
 if rigel:
   frameWidth  = 800
@@ -15,8 +16,13 @@ if rigel:
 elif realsense:
   frameWidth = 848
   frameHeight = 800
+elif mock:
+  frameWidth = 512
+  frameHeight = 512
 
 northStarSize = (2880, 1600)
+if mock:
+  northStarSize = (1024, 512)
 
 whiteBrightness = 127
 
@@ -49,6 +55,11 @@ elif realsense:
   print("starting intel thread (at %f)" % time.time())
   cap.start()
   print("started intel thread (at %f)" % time.time())
+elif mock:
+  class MockCapture:
+    def read(self):
+      return True, displayedBuffer
+  cap = MockCapture()
 
 if rigel:
   # Turn the Rigel Exposure Up
@@ -70,6 +81,7 @@ while (not (key & 0xFF == ord('q'))):
     newFrame, frame = cap.read()
     print("got a frame at %f" % time.time())
     if (newFrame):
+        time.sleep(0.1)
         print("got a new frame")
         # Reshape our one-dimensional image into a two-channel side-by-side view of the Rigel's feed
         frame       = np.reshape  (frame, (frameHeight, frameWidth * 2))

--- a/Software/North Star Gen 2/North Star Calibrator/captureGraycodes.py
+++ b/Software/North Star Gen 2/North Star Calibrator/captureGraycodes.py
@@ -27,11 +27,11 @@ if mock:
 whiteBrightness = 127
 
 allWhite           = np.ones      ((northStarSize[1], northStarSize[0]), dtype=np.uint8) * 100
-continuum          = np.arange    (0, 256,         dtype=np.float)
-widthContinuum     = np.zeros     (allWhite.shape, dtype=np.float)
-widthContinuum[:, : int(northStarSize[0] / 2)]   = cv2.resize(continuum[None, :], (int(northStarSize[0] / 2), northStarSize[1]), interpolation=cv2.INTER_LINEAR_EXACT)
+continuum          = np.arange    (0, 256,         dtype=np.uint8)
+widthContinuum     = np.zeros     (allWhite.shape, dtype=np.uint8)
+widthContinuum[:, : int(northStarSize[0] / 2)]   = cv2.resize(continuum[None, :], (int(northStarSize[0] / 2), northStarSize[1]), interpolation=cv2.INTER_NEAREST)
 widthContinuum[:,   int(northStarSize[0] / 2) :] = widthContinuum[:, : int(northStarSize[0] / 2)]
-heightContinuum    = cv2.resize   (continuum      [:, None      ], northStarSize, interpolation=cv2.INTER_LINEAR_EXACT)
+heightContinuum    = cv2.resize   (continuum      [:, None      ], northStarSize, interpolation=cv2.INTER_NEAREST)
 widthBits          = np.unpackbits(widthContinuum [:,    :, None].astype(np.uint8), axis=-1)
 heightBits         = np.unpackbits(heightContinuum[:,    :, None].astype(np.uint8), axis=-1)
 widthMeasuredBits  = np.zeros ((frameHeight, frameWidth * 2, 8), dtype=np.uint8)


### PR DESCRIPTION
Despite the name, the current implementation uses binary coding, not Gray (reflected binary) coding. This pull request implements actual Gray coding, as well as making a few partially related changes:

* Add a mock camera for testing. This also allows verification that in ideal circumstances, the output is near perfect.

* Change `INTER_LINEAR_EXACT` to `INTER_NEAREST` in the code. This seems to have fixed the artifacts previously observed.

* Remove a seemingly broken check: 
  ```python
            if stage % 2 is 0:
              if stage is not 17:
                darkFrameBuffer = frame.copy()
  ```
  It seems to me that this condition is always hit, so I instead reset all relevant buffers in the section above.

It's also worth noting that this change seems to invert the gradient direction, but that's easily rectified if it's an issue.

Here are some screenshots of the improvement:

Before (simulated 2px per-frame boundary noise): 
![WidthCalibration](https://user-images.githubusercontent.com/2837174/81894322-5ec0eb80-95a7-11ea-9da5-c36af1843e0a.png)
After (same input noise, new code):
![WidthCalibration](https://user-images.githubusercontent.com/2837174/81894418-a0519680-95a7-11ea-999d-d8c52108cd0c.png)


